### PR TITLE
feat(build): add Raspberry Pi 5 (Cortex-A76) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ arm_tune = "cortex-a72"
 
 When tuning for pi 5:
 ```
-arm_cpu = "cortex-a76+nocrypto"
+arm_cpu = "cortex-a76"
 arm_tune = "cortex-a76"
 ```
 
@@ -65,7 +65,7 @@ This will result in the clang compiler being invoked with the following args:
 | pi3             | `--target=armv7-linux-gnueabihf    -mcpu=cortex-a53+nocrypto -mtune=cortex-a53`[^3] |
 | aarch64-generic | `--target=aarch64-linux-gnu        -mcpu=generic             -mtune=generic`    |
 | pi4-64          | `--target=aarch64-linux-gnu        -mcpu=cortex-a72+nocrypto -mtune=cortex-a72`[^1] |
-| pi5-64          | `--target=aarch64-linux-gnu        -mcpu=cortex-a76+nocrypto -mtune=cortex-a76`[^4] |
+| pi5-64          | `--target=aarch64-linux-gnu        -mcpu=cortex-a76          -mtune=cortex-a76`     |
 | pi3-64          | `--target=aarch64-linux-gnu        -mcpu=cortex-a53+nocrypto -mtune=cortex-a53`[^3] |
 | x64-generic     | `--target=x86_64-unknown-linux-gnu -mcpu=generic             -mtune=generic` |
 
@@ -90,7 +90,5 @@ objcopy --strip-unneeded libflutter_engine.so
 [^1]: The CPU of the Raspberry Pi 4 is a Cortex-A72. `+nocrypto` is specified for `-mcpu` because the A72 in the Pi 4 is (_apparently_) the only A72 in the world that doesn't support cryptography instructions: https://github.com/ardera/flutter-ci/issues/3#issuecomment-1272330857
 
 [^3]: Pi 3 doesn't support cryptography extensions either.
-
-[^4]: The Raspberry Pi 5 uses a Cortex-A76. Using `+nocrypto` for consistency with Pi 3/Pi 4 builds, though the A76 in Pi 5 does support crypto extensions.
 
 [^2]: `--arm-float-abi hard` is only specified when building for armv7, `--unoptimized` is only specified for unoptimized debug builds.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # flutter engine binaries for armv7, aarch64, x64
 
 This repo contains flutter engine binaries (in the https://github.com/ardera/flutter-engine-binaries-for-arm filesystem layout) for armv7 and aarch64.
-The binaries come in 2 variants: generic, and tuned for the Pi 4 CPU.
+The binaries come in variants: generic, and tuned for the Pi 3, Pi 4, and Pi 5 CPUs.
 
 # 📦 Downloads
 
@@ -46,6 +46,12 @@ arm_cpu = "cortex-a72+nocrypto"
 arm_tune = "cortex-a72"
 ```
 
+When tuning for pi 5:
+```
+arm_cpu = "cortex-a76+nocrypto"
+arm_tune = "cortex-a76"
+```
+
 For both armv7 and aarch64, the engine is built against the sysroot provided by the engine build scripts, which is some debian sid sysroot from 2020.
 (See https://github.com/flutter/buildroot/blob/master/build/linux/sysroot_scripts/install-sysroot.py)
 
@@ -59,6 +65,7 @@ This will result in the clang compiler being invoked with the following args:
 | pi3             | `--target=armv7-linux-gnueabihf    -mcpu=cortex-a53+nocrypto -mtune=cortex-a53`[^3] |
 | aarch64-generic | `--target=aarch64-linux-gnu        -mcpu=generic             -mtune=generic`    |
 | pi4-64          | `--target=aarch64-linux-gnu        -mcpu=cortex-a72+nocrypto -mtune=cortex-a72`[^1] |
+| pi5-64          | `--target=aarch64-linux-gnu        -mcpu=cortex-a76+nocrypto -mtune=cortex-a76`[^4] |
 | pi3-64          | `--target=aarch64-linux-gnu        -mcpu=cortex-a53+nocrypto -mtune=cortex-a53`[^3] |
 | x64-generic     | `--target=x86_64-unknown-linux-gnu -mcpu=generic             -mtune=generic` |
 
@@ -83,5 +90,7 @@ objcopy --strip-unneeded libflutter_engine.so
 [^1]: The CPU of the Raspberry Pi 4 is a Cortex-A72. `+nocrypto` is specified for `-mcpu` because the A72 in the Pi 4 is (_apparently_) the only A72 in the world that doesn't support cryptography instructions: https://github.com/ardera/flutter-ci/issues/3#issuecomment-1272330857
 
 [^3]: Pi 3 doesn't support cryptography extensions either.
+
+[^4]: The Raspberry Pi 5 uses a Cortex-A76. Using `+nocrypto` for consistency with Pi 3/Pi 4 builds, though the A76 in Pi 5 does support crypto extensions.
 
 [^2]: `--arm-float-abi hard` is only specified when building for armv7, `--unoptimized` is only specified for unoptimized debug builds.

--- a/workflow_tool/lib/workflow_tool.dart
+++ b/workflow_tool/lib/workflow_tool.dart
@@ -86,7 +86,7 @@ enum CPU {
   generic('generic', 'generic'),
   pi3('cortex-a53+nocrypto', 'cortex-a53'),
   pi4('cortex-a72+nocrypto', 'cortex-a72'),
-  pi5('cortex-a76+nocrypto', 'cortex-a76');
+  pi5('cortex-a76', 'cortex-a76');
 
   const CPU(this.compilerCpu, this.cmopilerTune);
 

--- a/workflow_tool/lib/workflow_tool.dart
+++ b/workflow_tool/lib/workflow_tool.dart
@@ -85,7 +85,8 @@ enum Arch {
 enum CPU {
   generic('generic', 'generic'),
   pi3('cortex-a53+nocrypto', 'cortex-a53'),
-  pi4('cortex-a72+nocrypto', 'cortex-a72');
+  pi4('cortex-a72+nocrypto', 'cortex-a72'),
+  pi5('cortex-a76+nocrypto', 'cortex-a76');
 
   const CPU(this.compilerCpu, this.cmopilerTune);
 
@@ -134,6 +135,12 @@ enum Target {
     arch: Arch.arm64,
     cpu: CPU.pi4,
     name: 'pi4-64',
+    triple: 'aarch64-linux-gnu',
+  ),
+  pi5_64(
+    arch: Arch.arm64,
+    cpu: CPU.pi5,
+    name: 'pi5-64',
     triple: 'aarch64-linux-gnu',
   ),
   riscv64(


### PR DESCRIPTION
## Summary

Add support for building Flutter engine binaries optimized for Raspberry Pi 5 (Cortex-A76).

### Changes

- Add `pi5` to CPU enum with Cortex-A76 compiler flags
- Add `pi5_64` target for 64-bit ARM engine builds
- Update README with Pi5 build configuration and compiler invocation table

### Compiler flags

```
arm_cpu = "cortex-a76+nocrypto"
arm_tune = "cortex-a76"
```

Resulting in: `--target=aarch64-linux-gnu -mcpu=cortex-a76+nocrypto -mtune=cortex-a76`

## Notes

- Pi5 is 64-bit only (no 32-bit variant)
- Using `+nocrypto` for consistency with Pi3/Pi4 builds, though the A76 in Pi5 does support crypto extensions

## Test plan

- [x] Workflow builds pi5-64 profile and release engines successfully
- [x] Built and deployed Flutter app to Raspberry Pi 5 hardware
- [x] Verified app runs correctly with Pi5-optimized engine